### PR TITLE
compress payload so it's faster to insert into the database

### DIFF
--- a/components/GeneratingProgress.js
+++ b/components/GeneratingProgress.js
@@ -1,0 +1,40 @@
+import React from "react";
+
+export const GeneratingProgress = ({ status }) => {
+  return (
+    <div className="mt-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+      <div className="flex items-center">
+        <div className="mr-3">
+          <svg
+            className="animate-spin h-5 w-5 text-blue-500"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            ></circle>
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            ></path>
+          </svg>
+        </div>
+        <div>
+          <p className="text-sm font-medium text-blue-700">
+            {status || "Preparing transaction..."}
+          </p>
+          <p className="text-xs text-blue-600 mt-0.5">
+            Please wait while the transaction is being prepared.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/ProposalKeySection.js
+++ b/components/ProposalKeySection.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { KeysTableSelector } from "./KeysTableSelector";
 import { CopyLink } from "./CopyLink";
+import { GeneratingProgress } from "./GeneratingProgress";
 
 export const ProposalKeySection = ({
   accounts,
@@ -91,42 +92,7 @@ export const ProposalKeySection = ({
           </button>
 
           {/* Progress indicator for large payloads */}
-          {generating && (
-            <div className="mt-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-              <div className="flex items-center">
-                <div className="mr-3">
-                  <svg
-                    className="animate-spin h-5 w-5 text-blue-500"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    ></circle>
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    ></path>
-                  </svg>
-                </div>
-                <div>
-                  <p className="text-sm font-medium text-blue-700">
-                    {generatingStatus || "Preparing transaction..."}
-                  </p>
-                  <p className="text-xs text-blue-600 mt-0.5">
-                    Please wait while the transaction is being prepared.
-                  </p>
-                </div>
-              </div>
-            </div>
-          )}
+          {generating && <GeneratingProgress status={generatingStatus} />}
 
           {/* Page URL */}
           <div className="mt-3">

--- a/components/ProposalKeySection.js
+++ b/components/ProposalKeySection.js
@@ -8,6 +8,7 @@ export const ProposalKeySection = ({
   setProposalKey,
   onGenerateLink,
   generating,
+  generatingStatus,
   hasInFlightRequest,
   getFormUrlLink,
 }) => {
@@ -52,7 +53,7 @@ export const ProposalKeySection = ({
 
           {/* Generate Link button */}
           <button
-            className={`py-1.5 px-6 text-sm text-white font-medium rounded shadow-sm transition-colors ${
+            className={`py-2 px-6 text-sm text-white font-medium rounded shadow-sm transition-colors ${
               generating || selectedProposalKey === null || hasInFlightRequest
                 ? "bg-gray-300 cursor-not-allowed"
                 : "bg-blue-500 hover:bg-blue-600 active:bg-blue-700"
@@ -63,7 +64,7 @@ export const ProposalKeySection = ({
             {generating ? (
               <span className="flex items-center justify-center">
                 <svg
-                  className="animate-spin -ml-1 mr-2 h-3 w-3 text-white"
+                  className="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"
                   viewBox="0 0 24 24"
@@ -82,12 +83,50 @@ export const ProposalKeySection = ({
                     d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                   ></path>
                 </svg>
-                Generating...
+                Processing...
               </span>
             ) : (
               "Generate Tx Payload"
             )}
           </button>
+
+          {/* Progress indicator for large payloads */}
+          {generating && (
+            <div className="mt-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+              <div className="flex items-center">
+                <div className="mr-3">
+                  <svg
+                    className="animate-spin h-5 w-5 text-blue-500"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    ></circle>
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    ></path>
+                  </svg>
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-blue-700">
+                    {generatingStatus || "Preparing transaction..."}
+                  </p>
+                  <p className="text-xs text-blue-600 mt-0.5">
+                    Please wait while the transaction is being prepared.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
 
           {/* Page URL */}
           <div className="mt-3">

--- a/components/TransactionItem.js
+++ b/components/TransactionItem.js
@@ -4,7 +4,6 @@ import { AddressItem } from "./AddressItem";
 export const TransactionItem = ({ transaction, selectedTx, handleTxSelect, network }) => {
     return (
         <button
-            key={transaction.signatureRequestId}
             onClick={() => handleTxSelect(transaction)}
             className={`w-full text-left p-2 mb-2 rounded text-sm group ${
                 transaction === selectedTx ? 'bg-blue-100' : 'hover:bg-gray-100'

--- a/pages/[env]/index.js
+++ b/pages/[env]/index.js
@@ -15,7 +15,7 @@ import {
   TRANSFERESCROW,
 } from "../../utils/payloads";
 import { getCliCommand } from "../../utils/kmsHelpers";
-import { authzManyKeyResolver, buildSinglaAuthz } from "../../utils/authz";
+import { authzManyKeyResolver, buildSinglaAuthz, clearRegistrationState } from "../../utils/authz";
 import { MAINNET, TESTNET } from "../../utils/constants";
 import { TransactionCreationSection } from "../../components/TransactionCreationSection";
 import { ProposalKeySection } from "../../components/ProposalKeySection";
@@ -113,6 +113,7 @@ export default function MainPage() {
   const [transactionErrorMessage, setTransactionErrorMessage] = useState(null);
   const [triggerSent, setTriggerSent] = useState(false);
   const [generating, setGenerating] = useState(false);
+  const [generatingStatus, setGeneratingStatus] = useState("");
   const [signingFlowActive, setSigningFlowActive] = useState(false);
 
   const isLedgerDisabled = true;
@@ -246,9 +247,13 @@ export default function MainPage() {
   // Transaction submission
   const onSubmit = async (accountKey) => {
     setGenerating(true);
+    setGeneratingStatus("Preparing transaction...");
     setTransactionErrorMessage(null);
     setTriggerSent(false);
     setSigningFlowActive(true);
+    
+    // Clear any stale registration state from previous transactions
+    clearRegistrationState();
 
     const account = accounts[accountKey];
     const keys = account.keys;
@@ -256,6 +261,7 @@ export default function MainPage() {
     if (selectedProposalKey === null) {
       setTransactionErrorMessage("Please select a proposal key");
       setGenerating(false);
+      setGeneratingStatus("");
       return;
     }
 
@@ -265,6 +271,7 @@ export default function MainPage() {
     if (!proposalKey) {
       setTransactionErrorMessage("Selected proposal key not found");
       setGenerating(false);
+      setGeneratingStatus("");
       return;
     }
 
@@ -276,12 +283,15 @@ export default function MainPage() {
         `Invalid JSON arguments: ${parseError.message}`
       );
       setGenerating(false);
+      setGeneratingStatus("");
       return;
     }
 
     console.log(
       `[onSubmit] Starting transaction with ${keys.length} keys, proposer key: ${proposalKey.index}`
     );
+    
+    setGeneratingStatus(`Saving transaction payload for ${keys.length} keys...`);
 
     const authorizations = [
       authzManyKeyResolver(
@@ -325,12 +335,14 @@ export default function MainPage() {
             e.message || "An error occurred during the transaction"
           );
           setGenerating(false);
+          setGeneratingStatus("");
           setTriggerSent(false);
           setSigningFlowActive(false);
           return null;
         })
         .finally(() => {
           setGenerating(false);
+          setGeneratingStatus("");
         });
 
       if (tx?.transactionId) {
@@ -344,6 +356,7 @@ export default function MainPage() {
       console.error("[onSubmit] Unexpected transaction error:", e);
       setTransactionErrorMessage(e.message || "An unexpected error occurred");
       setGenerating(false);
+      setGeneratingStatus("");
       setTriggerSent(false);
       setSigningFlowActive(false);
       return;
@@ -557,6 +570,7 @@ export default function MainPage() {
               setProposalKey={setProposalKey}
               onGenerateLink={onSubmit}
               generating={generating}
+              generatingStatus={generatingStatus}
               hasInFlightRequest={hasInFlightRequest}
               getFormUrlLink={getFormUrlLink}
             />

--- a/pages/api/[signatureRequestId]/envelope.js
+++ b/pages/api/[signatureRequestId]/envelope.js
@@ -1,5 +1,6 @@
 import { supabase } from "../../../utils/supabaseClient";
 import { decode } from "rlp";
+import { decompressSignable } from "../../../utils/compression";
 
 const unique = (value, index, self) => {
   return self.indexOf(value) === index;
@@ -67,8 +68,14 @@ export default async function handler({ body, method, query }, res) {
         });
       }
 
+      // Decompress signable if compressed
+      const decompressedData = data?.map(row => ({
+        ...row,
+        signable: decompressSignable(row.signable),
+      }));
+
       return res.status(200).json({
-        data,
+        data: decompressedData,
       });
 
     default:

--- a/pages/api/[signatureRequestId]/index.js
+++ b/pages/api/[signatureRequestId]/index.js
@@ -1,5 +1,6 @@
 import * as fcl from "@onflow/fcl";
 import { supabase } from "../../../utils/supabaseClient";
+import { decompressSignable } from "../../../utils/compression";
 
 // Configure the API route to accept larger payloads (e.g., 10MB)
 export const config = {
@@ -55,8 +56,14 @@ export default async function handler({ body, method, query }, res) {
         });
       }
 
+      // Decompress signable if compressed
+      const decompressedData = postData?.map(row => ({
+        ...row,
+        signable: decompressSignable(row.signable),
+      }));
+
       return res.status(200).json({
-        data: postData,
+        data: decompressedData,
       });
 
     default:

--- a/pages/api/[signatureRequestId]/signable.js
+++ b/pages/api/[signatureRequestId]/signable.js
@@ -1,9 +1,10 @@
-import * as fcl from "@onflow/fcl";
 import { supabase } from "../../../utils/supabaseClient";
+import { decompressSignable } from "../../../utils/compression";
 
 export default async function handler({ body, method, query }, res) {
   switch (method) {
     case "GET":
+      // Each key has its own copy of the compressed signable
       const { data, error, status } = await supabase
         .from("payloadSigs")
         .select("sig, keyId, address, signable")
@@ -11,14 +12,20 @@ export default async function handler({ body, method, query }, res) {
         .limit(1);
 
       // Could not find row.
-      if (status === 406) {
+      if (status === 406 || !data || data.length === 0) {
         return res.status(404).json({
-          error,
+          error: error || "Signable not found",
         });
       }
 
+      // Decompress signable if it was compressed
+      const decompressedData = data.map(row => ({
+        ...row,
+        signable: decompressSignable(row.signable),
+      }));
+
       return res.status(200).json({
-        data,
+        data: decompressedData,
       });
 
 

--- a/pages/api/pending/rlp/[signatureRequestId]/index.js
+++ b/pages/api/pending/rlp/[signatureRequestId]/index.js
@@ -44,11 +44,12 @@ export default async function handler({ body, method, query }, res) {
       const { data, error, status } = await supabase
         .from("payloadSigs")
         .select("rlp")
-        .match(query);
+        .match(query)
+        .limit(1);
 
       // Could not find row.
-      if (status === 406) {
-        return res.status(404).send(error);
+      if (status === 406 || !data || data.length === 0) {
+        return res.status(404).send(error || "RLP not found");
       }
       return res.status(200).send(data[0].rlp);
 

--- a/pages/api/signatures/[address]/[keyId]/[signatureRequestId]/index.js
+++ b/pages/api/signatures/[address]/[keyId]/[signatureRequestId]/index.js
@@ -1,4 +1,5 @@
 import { supabase } from "../../../../../../utils/supabaseClient.js";
+import { decompressSignable } from "../../../../../../utils/compression.js";
 
 export default async function handler({ body, method, query }, res) {
   switch (method) {
@@ -16,7 +17,13 @@ export default async function handler({ body, method, query }, res) {
         });
       }
 
-      return res.status(200).json(data);
+      // Decompress signable if compressed
+      const decompressedData = data ? {
+        ...data,
+        signable: decompressSignable(data.signable),
+      } : data;
+
+      return res.status(200).json(decompressedData);
 
     default:
       return res.status(405);

--- a/pages/api/signatures/batch.js
+++ b/pages/api/signatures/batch.js
@@ -3,6 +3,7 @@ import {
   encodeVoucherToEnvelope,
   getSignatureRequestIdFromRLP,
 } from "../../../utils/fclCLI";
+import { compressSignable } from "../../../utils/compression";
 
 // Configure the API route to accept larger payloads
 export const config = {
@@ -10,11 +11,58 @@ export const config = {
     bodyParser: {
       sizeLimit: '10mb',
     },
+    // Increase timeout for large payloads
+    responseLimit: false,
   },
 };
 
+// Helper to wait before retry
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Upsert a single row with retry logic
+async function upsertWithRetry(row, maxRetries = 3) {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const { error } = await supabase.from("payloadSigs").upsert(row);
+      
+      if (!error) {
+        return { success: true, keyId: row.keyId };
+      }
+      
+      // Check if it's a timeout error that might succeed on retry
+      const isRetryable = error.message?.includes("statement timeout") || 
+                          error.message?.includes("canceling statement") ||
+                          error.message?.includes("timeout") ||
+                          error.code === "57014";
+      
+      if (isRetryable && attempt < maxRetries) {
+        console.log(`[Batch API] Retry ${attempt}/${maxRetries} for key ${row.keyId} after timeout`);
+        await wait(1000 * attempt); // Exponential backoff: 1s, 2s, 3s
+        continue;
+      }
+      
+      return { success: false, keyId: row.keyId, error: error.message };
+    } catch (err) {
+      if (attempt < maxRetries) {
+        console.log(`[Batch API] Retry ${attempt}/${maxRetries} for key ${row.keyId} after error: ${err.message}`);
+        await wait(1000 * attempt);
+        continue;
+      }
+      return { success: false, keyId: row.keyId, error: err.message };
+    }
+  }
+  return { success: false, keyId: row.keyId, error: "Max retries exceeded" };
+}
+
+// Process a chunk of keys in parallel
+async function processChunk(rows) {
+  const results = await Promise.all(rows.map(row => upsertWithRetry(row)));
+  return results;
+}
+
 /**
  * Batch registration endpoint for all keys in a multisig transaction.
+ * Uses chunked parallel inserts for speed while avoiding timeouts.
  * 
  * POST body:
  * {
@@ -49,30 +97,62 @@ export default async function handler({ body, method }, res) {
 
     console.log(`[Batch API] signatureRequestId: ${signatureRequestId?.slice(0, 8)}...`);
 
-    // Build rows for all keys
+    // Keep only essential fields from signable
+    const essentialSignable = {
+      addr: signable.addr,
+      keyId: signable.keyId,
+      voucher: signable.voucher,
+    };
+    
+    // Compress the signable to reduce storage size (can reduce by 70-90%)
+    const compressedSignable = compressSignable(essentialSignable);
+
+    const errors = [];
+    
+    // Build rows for all keys with compressed signable
+    // Each key gets its own copy of the compressed payload (simpler for dashboard lookups)
     const rows = keys.map(({ keyId, publicKey }) => ({
       signatureRequestId,
       keyId,
       address,
-      signable,
+      signable: compressedSignable,
       rlp: cliRLP,
       publicKey,
     }));
 
-    // Insert all keys in one operation
-    const { error } = await supabase
-      .from("payloadSigs")
-      .upsert(rows);
-
-    if (error) {
-      console.error(`[Batch API] Upsert failed:`, error.message, error);
-      return res.status(500).json({
-        error: `Failed to save keys: ${error.message}`,
-        signatureRequestId,
+    console.log(`[Batch API] Inserting ${rows.length} keys with compressed payload in parallel chunks...`);
+    
+    // Process in chunks of 3 keys in parallel (smaller chunks since each has payload)
+    const CHUNK_SIZE = 3;
+    for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+      const chunk = rows.slice(i, i + CHUNK_SIZE);
+      const chunkNum = Math.floor(i / CHUNK_SIZE) + 1;
+      const totalChunks = Math.ceil(rows.length / CHUNK_SIZE);
+      
+      console.log(`[Batch API] Processing chunk ${chunkNum}/${totalChunks} (${chunk.length} keys)...`);
+      
+      const results = await processChunk(chunk);
+      
+      // Collect any errors
+      results.forEach(result => {
+        if (!result.success) {
+          errors.push({ keyId: result.keyId, error: result.error });
+        }
       });
     }
 
-    console.log(`[Batch API] Successfully registered ${keys.length} keys`);
+    if (errors.length > 0) {
+      console.error(`[Batch API] ${errors.length} keys failed to insert:`, errors);
+      // Return partial success - first key with signable succeeded
+      return res.status(207).json({
+        warning: `${errors.length} of ${keys.length} keys failed to save`,
+        signatureRequestId,
+        keysRegistered: keys.length - errors.length,
+        failedKeys: errors,
+      });
+    }
+
+    console.log(`[Batch API] Successfully registered all ${keys.length} keys`);
     
     return res.status(200).json({
       signatureRequestId,

--- a/pages/api/signatures/batch.js
+++ b/pages/api/signatures/batch.js
@@ -11,22 +11,21 @@ export const config = {
     bodyParser: {
       sizeLimit: '10mb',
     },
-    // Increase timeout for large payloads
-    responseLimit: false,
   },
 };
 
 // Helper to wait before retry
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-// Upsert a single row with retry logic
-async function upsertWithRetry(row, maxRetries = 3) {
+// Batch upsert with retry logic
+async function batchUpsertWithRetry(rows, maxRetries = 3) {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      const { error } = await supabase.from("payloadSigs").upsert(row);
+      // Supabase supports batch upsert natively - much faster than individual inserts
+      const { error } = await supabase.from("payloadSigs").upsert(rows);
       
       if (!error) {
-        return { success: true, keyId: row.keyId };
+        return { success: true, count: rows.length };
       }
       
       // Check if it's a timeout error that might succeed on retry
@@ -36,28 +35,22 @@ async function upsertWithRetry(row, maxRetries = 3) {
                           error.code === "57014";
       
       if (isRetryable && attempt < maxRetries) {
-        console.log(`[Batch API] Retry ${attempt}/${maxRetries} for key ${row.keyId} after timeout`);
+        console.log(`[Batch API] Retry ${attempt}/${maxRetries} for batch of ${rows.length} keys after timeout`);
         await wait(1000 * attempt); // Exponential backoff: 1s, 2s, 3s
         continue;
       }
       
-      return { success: false, keyId: row.keyId, error: error.message };
+      return { success: false, error: error.message, failedKeys: rows.map(r => r.keyId) };
     } catch (err) {
       if (attempt < maxRetries) {
-        console.log(`[Batch API] Retry ${attempt}/${maxRetries} for key ${row.keyId} after error: ${err.message}`);
+        console.log(`[Batch API] Retry ${attempt}/${maxRetries} for batch after error: ${err.message}`);
         await wait(1000 * attempt);
         continue;
       }
-      return { success: false, keyId: row.keyId, error: err.message };
+      return { success: false, error: err.message, failedKeys: rows.map(r => r.keyId) };
     }
   }
-  return { success: false, keyId: row.keyId, error: "Max retries exceeded" };
-}
-
-// Process a chunk of keys in parallel
-async function processChunk(rows) {
-  const results = await Promise.all(rows.map(row => upsertWithRetry(row)));
-  return results;
+  return { success: false, error: "Max retries exceeded", failedKeys: rows.map(r => r.keyId) };
 }
 
 /**
@@ -78,9 +71,25 @@ export default async function handler({ body, method }, res) {
 
   const { signable, keys, address } = body;
 
+  // Validate required fields
   if (!signable?.voucher || !keys || !address) {
     return res.status(400).json({ 
       error: "Missing required fields: signable, keys, or address" 
+    });
+  }
+
+  // Validate keys array
+  if (!Array.isArray(keys) || keys.length === 0) {
+    return res.status(400).json({ 
+      error: "Keys must be a non-empty array" 
+    });
+  }
+
+  // Validate each key has required fields
+  const invalidKeys = keys.filter(k => typeof k.keyId !== 'number' || !k.publicKey);
+  if (invalidKeys.length > 0) {
+    return res.status(400).json({ 
+      error: "Each key must have keyId (number) and publicKey (string)" 
     });
   }
 
@@ -120,30 +129,37 @@ export default async function handler({ body, method }, res) {
       publicKey,
     }));
 
-    console.log(`[Batch API] Inserting ${rows.length} keys with compressed payload in parallel chunks...`);
+    console.log(`[Batch API] Inserting ${rows.length} keys with compressed payload...`);
     
-    // Process in chunks of 3 keys in parallel (smaller chunks since each has payload)
-    const CHUNK_SIZE = 3;
-    for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
-      const chunk = rows.slice(i, i + CHUNK_SIZE);
-      const chunkNum = Math.floor(i / CHUNK_SIZE) + 1;
-      const totalChunks = Math.ceil(rows.length / CHUNK_SIZE);
-      
-      console.log(`[Batch API] Processing chunk ${chunkNum}/${totalChunks} (${chunk.length} keys)...`);
-      
-      const results = await processChunk(chunk);
-      
-      // Collect any errors
-      results.forEach(result => {
+    // For small batches (≤10 keys), insert all at once
+    // For larger batches, chunk to avoid payload size limits
+    const CHUNK_SIZE = 10;
+    
+    if (rows.length <= CHUNK_SIZE) {
+      // Single batch insert - fastest path
+      const result = await batchUpsertWithRetry(rows);
+      if (!result.success) {
+        errors.push(...(result.failedKeys || []).map(keyId => ({ keyId, error: result.error })));
+      }
+    } else {
+      // Chunked batch inserts for very large key sets
+      for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+        const chunk = rows.slice(i, i + CHUNK_SIZE);
+        const chunkNum = Math.floor(i / CHUNK_SIZE) + 1;
+        const totalChunks = Math.ceil(rows.length / CHUNK_SIZE);
+        
+        console.log(`[Batch API] Processing chunk ${chunkNum}/${totalChunks} (${chunk.length} keys)...`);
+        
+        const result = await batchUpsertWithRetry(chunk);
+        
         if (!result.success) {
-          errors.push({ keyId: result.keyId, error: result.error });
+          errors.push(...(result.failedKeys || []).map(keyId => ({ keyId, error: result.error })));
         }
-      });
+      }
     }
 
     if (errors.length > 0) {
       console.error(`[Batch API] ${errors.length} keys failed to insert:`, errors);
-      // Return partial success - first key with signable succeeded
       return res.status(207).json({
         warning: `${errors.length} of ${keys.length} keys failed to save`,
         signatureRequestId,

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -53,13 +53,19 @@ export default function Dashboard() {
     const requests = items?.data.map((i) => ({ ...i }));
 
     signableIds = [...signableIds, ...(requests || [])];
-    const allPending = signableIds.filter((t) => !t.sig);
+    
+    // Deduplicate by signatureRequestId to prevent duplicate React keys
+    const uniqueSignableIds = Array.from(
+      new Map(signableIds.map(item => [item.signatureRequestId, item])).values()
+    );
+    
+    const allPending = uniqueSignableIds.filter((t) => !t.sig);
     const now = new Date();
     const fifteenMinutes = 15 * 60 * 1000;
     const fifteenMinutesAgo = new Date(now - fifteenMinutes);
     const pending = allPending.filter((t) => new Date(t.created_at) > fifteenMinutesAgo);
 
-    const signed = signableIds.filter((t) => !!t.sig);
+    const signed = uniqueSignableIds.filter((t) => !!t.sig);
     setLoading(false);
     return { pending, signed };
   }, []);
@@ -105,7 +111,11 @@ export default function Dashboard() {
           return;
         }
         setPublicKey(accts.publicKey);
-        setAccounts([...accts.accounts] || []);
+        // Deduplicate accounts by address+keyId to prevent duplicate React keys
+        const uniqueAccounts = Array.from(
+          new Map(accts.accounts.map(a => [`${a.address}${a.keyId}`, a])).values()
+        );
+        setAccounts(uniqueAccounts || []);
         const { pending, signed } = await lookUpSignableTransactions(
           accts.publicKey
         );
@@ -220,7 +230,7 @@ export default function Dashboard() {
                 <>
                   {pendingTxs.map((tx) => (
                     <TransactionItem
-                      key={tx.signatureRequestId}
+                      key={`${tx.signatureRequestId}-${tx.keyId}`}
                       transaction={tx}
                       selectedTx={selectedTx}
                       handleTxSelect={handleTxSelect}
@@ -249,7 +259,7 @@ export default function Dashboard() {
               ) : (
                 signedTxs.map((s) => (
                   <TransactionItem
-                    key={s.signatureRequestId}
+                    key={`${s.signatureRequestId}-${s.keyId}`}
                     transaction={s}
                     selectedTx={selectedTx}
                     handleTxSelect={handleTxSelect}

--- a/utils/authz.js
+++ b/utils/authz.js
@@ -24,37 +24,106 @@ const fetchSignatureStatus = async (id) => {
   }
 };
 
+// Global registration state to prevent duplicate registrations across resolvers
+const globalRegistrationState = {
+  inProgress: {},  // address -> Promise
+  completed: {},   // address -> signatureRequestId
+};
+
+/**
+ * Clear the global registration state.
+ * Call this when starting a new transaction or clicking "Start Over".
+ */
+export const clearRegistrationState = () => {
+  console.log('[clearRegistrationState] Clearing global registration state');
+  globalRegistrationState.inProgress = {};
+  globalRegistrationState.completed = {};
+};
+
+// Fetch with timeout to prevent silent hangs
+const fetchWithTimeout = async (url, options, timeoutMs = 120000) => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    return response;
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error.name === 'AbortError') {
+      throw new Error(`Request timed out after ${timeoutMs / 1000} seconds`);
+    }
+    throw error;
+  }
+};
+
 /**
  * Register all keys using the batch API.
+ * Uses global state to prevent duplicate registrations.
  * Returns the signatureRequestId.
  */
 const registerAllKeysBatch = async (address, keys, signable) => {
-  console.log(`[registerAllKeysBatch] Registering ${keys.length} keys for address ${address}`);
+  const normalizedAddress = fcl.sansPrefix(address);
+  
+  // Check if registration already completed for this address
+  if (globalRegistrationState.completed[normalizedAddress]) {
+    console.log(`[registerAllKeysBatch] Using cached signatureRequestId for ${normalizedAddress}`);
+    return globalRegistrationState.completed[normalizedAddress];
+  }
+  
+  // Check if registration is already in progress
+  if (globalRegistrationState.inProgress[normalizedAddress]) {
+    console.log(`[registerAllKeysBatch] Waiting for in-progress registration for ${normalizedAddress}`);
+    return globalRegistrationState.inProgress[normalizedAddress];
+  }
+  
+  console.log(`[registerAllKeysBatch] Registering ${keys.length} keys for address ${normalizedAddress}`);
   
   const keysData = keys.map(k => ({
     keyId: k.index,
     publicKey: k.publicKey,
   }));
 
-  const response = await fetch('/api/signatures/batch', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      signable,
-      keys: keysData,
-      address: fcl.sansPrefix(address),
-    }),
-  });
+  // Create the registration promise and store it
+  const registrationPromise = (async () => {
+    const response = await fetchWithTimeout('/api/signatures/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        signable,
+        keys: keysData,
+        address: normalizedAddress,
+      }),
+    }, 60000); // 60 second timeout (compression makes this much faster)
 
-  const result = await response.json();
-  
-  if (!response.ok) {
-    throw new Error(result.error || `Failed to register keys: HTTP ${response.status}`);
-  }
+    const result = await response.json();
+    
+    // Handle partial success (207) - some keys may have failed but we can continue
+    if (response.status === 207) {
+      console.warn(`[registerAllKeysBatch] Partial success: ${result.warning}`);
+      // Continue with the signatureRequestId even if some keys failed
+    } else if (!response.ok) {
+      // Clear in-progress state on failure so retry is possible
+      delete globalRegistrationState.inProgress[normalizedAddress];
+      throw new Error(result.error || `Failed to register keys: HTTP ${response.status}`);
+    }
 
-  console.log(`[registerAllKeysBatch] Successfully registered ${result.keysRegistered} keys, signatureRequestId: ${result.signatureRequestId?.slice(0, 8)}...`);
+    console.log(`[registerAllKeysBatch] Successfully registered ${result.keysRegistered} keys, signatureRequestId: ${result.signatureRequestId?.slice(0, 8)}...`);
+    
+    // Cache the result
+    globalRegistrationState.completed[normalizedAddress] = result.signatureRequestId;
+    delete globalRegistrationState.inProgress[normalizedAddress];
+    
+    return result.signatureRequestId;
+  })();
   
-  return result.signatureRequestId;
+  globalRegistrationState.inProgress[normalizedAddress] = registrationPromise;
+  
+  return registrationPromise;
 };
 
 /**

--- a/utils/compression.js
+++ b/utils/compression.js
@@ -1,0 +1,52 @@
+import zlib from "zlib";
+
+/**
+ * Compress a JSON object using gzip and return as base64 string.
+ * This can reduce payload size by 70-90% for JSON data.
+ */
+export function compressSignable(signable) {
+  try {
+    const jsonStr = JSON.stringify(signable);
+    const originalSize = Buffer.byteLength(jsonStr, 'utf8');
+    
+    const compressed = zlib.gzipSync(jsonStr, { level: 9 }); // Max compression
+    const base64 = compressed.toString('base64');
+    const compressedSize = Buffer.byteLength(base64, 'utf8');
+    
+    const ratio = ((1 - compressedSize / originalSize) * 100).toFixed(1);
+    console.log(`[Compression] Compressed: ${(originalSize / 1024).toFixed(1)}KB → ${(compressedSize / 1024).toFixed(1)}KB (${ratio}% reduction)`);
+    
+    return {
+      _compressed: true,
+      _encoding: 'gzip+base64',
+      data: base64,
+    };
+  } catch (error) {
+    console.error('[Compression] Failed, storing uncompressed:', error.message);
+    return signable; // Fall back to uncompressed
+  }
+}
+
+/**
+ * Decompress a signable that was compressed with gzip+base64.
+ * Returns the original object, or the input if not compressed.
+ * Handles both compressed and uncompressed signables transparently.
+ */
+export function decompressSignable(signable) {
+  if (!signable) return signable;
+  
+  // Check if this is a compressed signable
+  if (signable._compressed && signable._encoding === 'gzip+base64' && signable.data) {
+    try {
+      const buffer = Buffer.from(signable.data, 'base64');
+      const decompressed = zlib.gunzipSync(buffer);
+      return JSON.parse(decompressed.toString('utf8'));
+    } catch (error) {
+      console.error('[Decompression] Failed:', error.message);
+      return signable; // Return as-is if decompression fails
+    }
+  }
+  
+  // Not compressed, return as-is (backwards compatible with old data)
+  return signable;
+}


### PR DESCRIPTION
Fix a few issues. 
When there are lots of keys on a multisig and the transaction payload is very large, it can timeout to insert into the database. Need to compress the payload to make it faster and easier to insert into the database. Chunk insert into the database to make sure all records get inserted, using batch of 10. 

Added wait indicator on "Generate tx payload" to give user feedback that all data has been inserted. 

When the dashboard queries the database it'll be faster to get the large payload and decompress it. 